### PR TITLE
Fix Serial wait loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,11 @@ void setup() {
   // put your setup code here, to run once:
   Serial.begin(115200);
 
-  // Wait for Serial to be ready
-  while (!Serial) {
-    // Wait for Serial to be ready
+  // Wait for Serial to be ready but do not block forever (max 5 seconds)
+  unsigned long start = millis();
+  while (!Serial && (millis() - start) < 5000) {
     delay(100);
-  } 
+  }
 
   const int pwmPin = 9; // Choose a PWM-capable pin
 


### PR DESCRIPTION
## Summary
- avoid blocking forever waiting for Serial to open

## Testing
- `pio run` *(fails: HTTPClientError due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_685021c3890c8321b290fb695d4d7566