### PR TITLE
Add yaw-enabled thruster control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# ROV Brain
+
+This project uses PlatformIO with the Arduino framework to control an ROV. A
+`ThrusterController` library is provided to manage a pair of thrusters.
+
+## ThrusterController
+
+The controller is initialised with the pins connected to the left and right
+thruster ESCs:
+
+```cpp
+#include <ThrusterController.h>
+
+ThrusterController thrusters(leftPin, rightPin);
+```
+
+Call `begin()` in `setup()` and then provide separate left and right thrust
+values with `setThrust(left, right)`.
+
+A convenience function `setThrustYaw(thrust, yaw)` can be used when you want to
+specify a forward thrust along with a yaw component. The controller will compute
+individual thruster values from these parameters.
+
+Both `thrust` and `yaw` (and the left/right values) are expected to be in the
+range `[-1.0, 1.0]`. Internally these values are mapped to the PWM duty cycle on
+the configured pins.
+
+## Building
+
+To build the firmware run:
+
+```bash
+pio run
+```
+
+PlatformIO will automatically build the library from the `lib` directory.

--- a/lib/ThrusterController/src/ThrusterController.cpp
+++ b/lib/ThrusterController/src/ThrusterController.cpp
@@ -1,0 +1,31 @@
+#include "ThrusterController.h"
+
+ThrusterController::ThrusterController(uint8_t leftPin, uint8_t rightPin)
+    : _leftPin(leftPin), _rightPin(rightPin) {}
+
+void ThrusterController::begin() {
+    pinMode(_leftPin, OUTPUT);
+    pinMode(_rightPin, OUTPUT);
+    analogWrite(_leftPin, 0);
+    analogWrite(_rightPin, 0);
+}
+
+void ThrusterController::writePWM(uint8_t pin, float value) {
+    // constrain value to [-1,1]
+    if (value > 1.0f) value = 1.0f;
+    if (value < -1.0f) value = -1.0f;
+    // map from [-1,1] to [0,255]
+    uint8_t duty = (uint8_t)((value + 1.0f) * 127.5f);
+    analogWrite(pin, duty);
+}
+
+void ThrusterController::setThrust(float left, float right) {
+    writePWM(_leftPin, left);
+    writePWM(_rightPin, right);
+}
+
+void ThrusterController::setThrustYaw(float thrust, float yaw) {
+    float left = thrust + yaw;
+    float right = thrust - yaw;
+    setThrust(left, right);
+}

--- a/lib/ThrusterController/src/ThrusterController.h
+++ b/lib/ThrusterController/src/ThrusterController.h
@@ -1,0 +1,27 @@
+#ifndef THRUSTER_CONTROLLER_H
+#define THRUSTER_CONTROLLER_H
+
+#include <Arduino.h>
+
+class ThrusterController {
+public:
+    ThrusterController(uint8_t leftPin, uint8_t rightPin);
+
+    void begin();
+
+    // Set individual thrust values for left and right thrusters
+    // each value should be in the range [-1.0, 1.0]
+    void setThrust(float left, float right);
+
+    // Convenience function for setting a forward thrust and yaw component
+    // Values should be in the range [-1.0, 1.0]
+    void setThrustYaw(float thrust, float yaw);
+
+private:
+    uint8_t _leftPin;
+    uint8_t _rightPin;
+
+    void writePWM(uint8_t pin, float value);
+};
+
+#endif // THRUSTER_CONTROLLER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,12 @@
 #include <Arduino.h>
+#include <ThrusterController.h>
+
+// Pins for the left and right thrusters
+static const uint8_t LEFT_THRUSTER_PIN = 9;
+static const uint8_t RIGHT_THRUSTER_PIN = 10;
+
+// Create the thruster controller with the chosen pins
+ThrusterController thrusters(LEFT_THRUSTER_PIN, RIGHT_THRUSTER_PIN);
 
 void setup() {
   // put your setup code here, to run once:
@@ -10,14 +18,15 @@ void setup() {
     delay(100);
   }
 
-  const int pwmPin = 9; // Choose a PWM-capable pin
-
-  pinMode(pwmPin, OUTPUT);
-  analogWrite(pwmPin, 0); // Initialize with 0 duty cycle
+  thrusters.begin();
 
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
+  // Example: rotate in place for one second, then stop for one second
+  thrusters.setThrust(0.5f, -0.5f); // apply yaw
+  delay(1000);
+  thrusters.setThrust(0.0f, 0.0f);
+  delay(1000);
 }
 


### PR DESCRIPTION
## Summary
- implement `ThrusterController` library supporting separate left/right thrust and yaw commands
- update example usage in `src/main.cpp`
- add project README explaining the new API

## Testing
- `pip install platformio`
- `pio run` *(fails: PlatformIO couldn't download required packages)*

------
https://chatgpt.com/codex/tasks/task_e_685039066f0883219eb7618e75e1fa40